### PR TITLE
Feature (reduce) Add accumulator for multiple options of same name

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,18 @@ Aliases: `cast`, `castTo`
 
 Perform a map operation on the value for this option.  Takes function that accepts a string $value and return mixed (you can map to whatever you wish).
 
+### `reduce (Closure $reducer)`
+
+Aliases: `list`, `each`, `every`
+
+Execute an accumulator/reducer function on every instance of the option in the command. Takes an accumulator function, and returns mixed (you can return any value). If you also supply a map for the option the map will execute on every value before it is passed to the accumulator function.
+
+Signature: `function(mixed $accumulated, mixed $value) : mixed`
+
+ - `$accumulated`: null|Option::default|mixed (the last value returned from the function, the option default value, or null.)
+ - `$value`: mixed (the value that comes after the option. if map is supplied, the value returned from the map function.)
+ - `return`: mixed (anything you want. The last value returned becomes the value of the Option after parsing.)
+
 ### `referToAs (string $name)`
 
 Aliases: `title`, `referredToAs`

--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,7 @@
     "version": "0.2.9",
     "autoload": {
         "psr-0": {"Commando": "src/"}
+    },
+    "require-dev": {
     }
 }

--- a/tests/Commando/CommandTest.php
+++ b/tests/Commando/CommandTest.php
@@ -139,6 +139,21 @@ class CommandTest extends \PHPUnit_Framework_TestCase
             ->boolean();
         $this->assertTrue($cmd['b']);
     }
+
+    public function testReduceOption() {
+        $tokens = array('filename', '--exclude', 'name1', '--exclude', 'name2');
+        $cmd = new Command($tokens);
+        $cmd
+            ->option('exclude')
+            ->reduce(function ($acc, $next) {
+                array_push($acc, $next);
+                return $acc;
+            })
+            ->default([]);
+
+        $this->assertEquals(2, count($cmd['exclude']));
+        $this->assertEquals(array('name1', 'name2'), $cmd['exclude']);
+    }
     
     public function testIncrementOption()
     {

--- a/tests/Commando/OptionTest.php
+++ b/tests/Commando/OptionTest.php
@@ -151,6 +151,36 @@ class OptionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test that the reducer gets set
+     */
+    public function testSetReducer()
+    {
+        $option = new Option('f');
+
+        $this->assertTrue(!$option->hasReducer());
+
+        $option->setReducer(function() {});
+        
+        $this->assertTrue($option->hasReducer());
+    }
+
+    /**
+     * Test that reducer is called
+     */
+    public function testReduce()
+    {
+        $option = new Option('f');
+        $isCalled = false;
+        $option->setReducer(function () use (&$isCalled) {
+            $isCalled = true;
+            return ($isCalled);
+        });
+
+        $this->assertTrue($this->reduce(null, null));
+        $this->assertTrue($isCalled);
+    }
+
+    /**
      * Test that the needed requirements are met
      */
     public function testOptionRequirementsMet()


### PR DESCRIPTION
 - Add `Option::reduce` to take an accumulator function that will be
called on every token of the same name in the token list.

 - Add `Option::hasReducer` to check that an Option has a reducer
assigned.

 - Update parse function for the case where a named token has an
Option with a reducer, and the token has a value preceding it.
The accumulator with call a `map` if also assigned on the token
value before calling the accumulator with the previous accumulated
value and the token value.