### PR TITLE
Refactor (Option::type) More consistant constants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     ],
     "require": {
         "php": ">=5.4",
-        "kevinlebrun/colors.php": "~0.2"
+        "kevinlebrun/colors.php": "~0.2",
+        "ducks-project/spl-types": "^1.0"
 
     },
     "version": "0.3.0",

--- a/src/Commando/Command.php
+++ b/src/Commando/Command.php
@@ -16,7 +16,10 @@
  * @method \Commando\Command default($value)
  */
 
+
 namespace Commando;
+
+use Commando\Option\TypeEnum;
 
 /**
  * Here are all the methods available through __call.  For accurate method documentation, see the actual method.
@@ -55,9 +58,9 @@ namespace Commando;
 
 class Command implements \ArrayAccess, \Iterator
 {
-    const OPTION_TYPE_ARGUMENT  = 1; // e.g. foo
-    const OPTION_TYPE_SHORT     = 2; // e.g. -u
-    const OPTION_TYPE_VERBOSE   = 4; // e.g. --username
+    const OPTION_TYPE_ARGUMENT  = TypeEnum::ARGUMENT; // e.g. foo
+    const OPTION_TYPE_SHORT     = TypeEnum::SHORT; // e.g. -u
+    const OPTION_TYPE_VERBOSE   = TypeEnum::LONG; // e.g. --username
 
     private
         $current_option             = null,
@@ -442,7 +445,7 @@ class Command implements \ArrayAccess, \Iterator
                 list($name, $type) = $this->_parseOption($token);
 
                 // We allow short groups
-                if (strlen($name) > 1 && $type === self::OPTION_TYPE_SHORT) {
+                if (strlen($name) > 1 && $type === TypeEnum::SHORT) {
 
                     $group = str_split($name);
                     // correct option name
@@ -456,7 +459,7 @@ class Command implements \ArrayAccess, \Iterator
                     }
                 }
 
-                if ($type === self::OPTION_TYPE_ARGUMENT) {
+                if ($type === TypeEnum::ARGUMENT) {
                     // its an argument, use an int as the index
                     $keyvals[$count] = $name;
 
@@ -495,7 +498,7 @@ class Command implements \ArrayAccess, \Iterator
                         // the next token MUST be an "argument" and not another flag/option
                         $token = array_shift($tokens);
                         list($val, $type) = $this->_parseOption($token);
-                        if ($type !== self::OPTION_TYPE_ARGUMENT)
+                        if ($type !== TypeEnum::ARGUMENT)
                             throw new \Exception(sprintf('Unable to parse option %s: Expected an argument', $token));
                         if (!$option->hasReducer()) {
                             $keyvals[$name] = $val;
@@ -515,8 +518,8 @@ class Command implements \ArrayAccess, \Iterator
             foreach ($this->options as $option) {
                 if (is_null($option->getValue()) && $option->isRequired()) {
                     throw new \Exception(sprintf('Required %s %s must be specified',
-                        $option->getType() & Option::TYPE_NAMED ?
-                            'option' : 'argument', $option->getName()));
+                        $option->getType() === TypeEnum::ARGUMENT ?
+                            'argument' : 'option', $option->getName()));
                 }
             }
 
@@ -546,15 +549,6 @@ class Command implements \ArrayAccess, \Iterator
             $this->sorted_keys = array_keys($this->options);
             natsort($this->sorted_keys);
 
-            // // See if our options have what they require
-            // foreach ($this->options as $option) {
-            //     $needs = $option->hasNeeds($keyvals);
-            //     if ($needs !== true) {
-            //         throw new \InvalidArgumentException(
-            //             'Option "'.$option->getName().'" does not have required option(s): '.implode(', ', $needs)
-            //         );
-            //     }
-            // }
         } catch(\Exception $e) {
             $this->error($e);
         }
@@ -606,12 +600,12 @@ class Command implements \ArrayAccess, \Iterator
 
         if (!empty($matches['hyphen'])) {
             $type = (strlen($matches['hyphen']) === 1) ?
-                self::OPTION_TYPE_SHORT:
-                self::OPTION_TYPE_VERBOSE;
+                TypeEnum::SHORT:
+                TypeEnum::LONG;
             return array($matches['name'], $type);
         }
 
-        return array($token, self::OPTION_TYPE_ARGUMENT);
+        return array($token, TypeEnum::ARGUMENT);
     }
 
 

--- a/src/Commando/Option.php
+++ b/src/Commando/Option.php
@@ -2,6 +2,7 @@
 
 namespace Commando;
 use \Commando\Util\Terminal;
+use \Commando\Option\TypeEnum;
 
 /**
  * Here are all the methods available through __call.  For accurate method documentation, see the actual method.
@@ -49,7 +50,7 @@ class Option
         $required = false, /* bool */
         $needs = array(), /* set of other required options for this option */
         $boolean = false, /* bool */
-        $type = 0, /* int see constants */
+        $type = 0, /* TypeEnum(int) */
         $rule, /* closure */
         $map, /* closure */
         $reducer, /* closure */
@@ -60,10 +61,10 @@ class Option
         $file_require_exists, /* bool require that the file path is valid */
         $file_allow_globbing; /* bool allow globbing for files */
 
-    const TYPE_SHORT        = 1;
-    const TYPE_VERBOSE      = 2;
-    const TYPE_NAMED        = 3; // 1|2
-    const TYPE_ANONYMOUS    = 4;
+    const TYPE_SHORT        = TypeEnum::SHORT;
+    const TYPE_VERBOSE      = TypeEnum::LONG;
+    const TYPE_NAMED        = (TypeEnum::SHORT | TypeEnum::LONG); // 1|2
+    const TYPE_ANONYMOUS    = TypeEnum::ARGUMENT;
 
     /**
      * @param string|int $name single char name or int index for this option
@@ -77,10 +78,9 @@ class Option
         }
 
         if (!is_int($name)) {
-            $this->type = mb_strlen($name, 'UTF-8') === 1 ?
-                self::TYPE_SHORT : self::TYPE_VERBOSE;
+            $this->type = new TypeEnum(mb_strlen($name, 'UTF-8') > 1 ? TypeEnum::LONG : TypeEnum::SHORT);
         } else {
-            $this->type = self::TYPE_ANONYMOUS;
+            $this->type = new TypeEnum(TypeEnum::ARGUMENT);
         }
 
         $this->name = $name;
@@ -325,7 +325,7 @@ class Option
      */
     public function getType()
     {
-        return $this->type;
+        return $this->type->value;
     }
 
     /**
@@ -465,15 +465,13 @@ class Option
         $color = new \Colors\Color();
         $help = '';
 
-        $isNamed = ($this->type & self::TYPE_NAMED);
+        $isNamed = $this->type->isNamed();
 
         if ($isNamed) {
-            $help .=  PHP_EOL . (mb_strlen($this->name, 'UTF-8') === 1 ?
-                '-' : '--') . $this->name;
+            $help .=  PHP_EOL . ($this->type->isType(TypeEnum::SHORT) ? '-' : '--') . $this->name;
             if (!empty($this->aliases)) {
                 foreach($this->aliases as $alias) {
-                    $help .= (mb_strlen($alias, 'UTF-8') === 1 ?
-                        '/-' : '/--') . $alias;
+                    $help .= (mb_strlen($alias, 'UTF-8') === 1 ? '/-' : '/--') . $alias;
                 }
             }
             if (!$this->isBoolean()) {

--- a/src/Commando/Option/TypeEnum.php
+++ b/src/Commando/Option/TypeEnum.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * TypeEnum Definition
+ * 
+ * @package nategood/commando
+ * @source src/Commando/Option/TypeEnum.php
+ */
+
+namespace Commando\Option;
+
+use Commando\Util\Enum;
+
+/**
+ * Class TypeEnum
+ * 
+ * Extend dynamic Enum
+ */
+class TypeEnum extends Enum
+{
+
+  const SHORT = 1;
+  const LONG = 2;
+  const ARGUMENT = 4;
+
+  /**
+   * Convenience method
+   * 
+   * Check if the instance value is LONG or SHORT
+   *
+   * @return boolean
+   */
+  public function isNamed()
+  {
+    return static::isValueNamed($this);
+  }
+
+  /**
+   * Check if the $value is one of LONG or SHORT
+   *
+   * @param mixed $value
+   * @return boolean
+   */
+  public static function isValueNamed($value)
+  {
+    return static::isValueType($value, (static::SHORT | static::LONG));
+  }
+
+}

--- a/src/Commando/Util/Enum.php
+++ b/src/Commando/Util/Enum.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Generate base Enum class
+ * 
+ * @package nategood/commando
+ * @source src/Commando/Util/Enum.php
+ */
+
+namespace Commando\Util;
+
+/**
+ * Trait EnumUtilitiesTrait
+ * 
+ * Prevent code duplication when defining our base Enum.
+ */
+trait EnumUtilitiesTrait
+{
+  /**
+   * Get value with magic
+   * 
+   * @method __get
+   * @param string $name
+   * @return void
+   */
+  public function __get($name) {
+    if ($name === 'value') {
+      return $this->__default;
+    }
+  }
+
+  /**
+   * Is the instance value equal to $type?
+   *
+   * @param mixed $type
+   * @return boolean
+   */
+  public function isType($type)
+  {
+    return static::isValueType($this, $type);
+  }
+
+  /**
+   * Is the $value equal to $type?
+   *
+   * @param mixed $value
+   * @param mixed $type
+   * @return boolean
+   */
+  public static function isValueType($value, $type)
+  {
+    $realValue = (int) is_subclass_of($value, self::class) ? static::extractValueFrom($value) : $value;
+    $realType = (int) is_a($type, self::class) ? static::extractValueFrom($type) : $type;
+
+    return (bool) ($realValue & $realType);
+  }
+
+  /**
+   * Get value of Enum
+   *
+   * @param Enum $value
+   * @return int
+   */
+  public static function extractValueFrom(Enum $value)
+  {
+    return $value->value;
+  }
+}
+
+if (class_exists("\\SplEnum")) {
+  /**
+   * Enum extending SPL_TYPES SplEnum
+   */
+  class Enum extends \SplEnum {
+    use EnumUtilitiesTrait;
+  }
+} else {
+  /**
+   * Enum extending ducks-project/spl-types SplEnum
+   */
+  class Enum extends \Ducks\Component\SplTypes\SplEnum {
+    use EnumUtilitiesTrait;
+  }
+}

--- a/tests/Commando/TypeEnumTest.php
+++ b/tests/Commando/TypeEnumTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Commando\Test;
+
+require dirname(dirname(__DIR__)) . '/vendor/autoload.php';
+
+// PHPUnit version hack https://stackoverflow.com/questions/6065730/why-fatal-error-class-phpunit-framework-testcase-not-found-in
+if (!class_exists('\PHPUnit_Framework_TestCase') && class_exists('\PHPUnit\Framework\TestCase'))
+    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
+
+use Commando\Option\TypeEnum;
+
+function errorHandlerFactory(&$caught) {
+  return function () use (&$caught) {
+    $caught = true;
+    return $caught;
+  };
+}
+
+class TypeEnumTest extends \PHPUnit_Framework_TestCase {
+
+  function testExtractValueFrom() {
+    $type = new TypeEnum(TypeEnum::SHORT);
+    $this->assertEquals(TypeEnum::extractValueFrom($type), TypeEnum::SHORT);
+  }
+
+  function testIsValueType() {
+    $type1 = new TypeEnum(TypeEnum::SHORT);
+    $type2 = new TypeEnum(TypeEnum::LONG);
+    $this->assertFalse(TypeEnum::isValueType(TypeEnum::SHORT, TypeEnum::LONG));
+    $this->assertFalse(TypeEnum::isValueType($type1, $type2));
+    $this->assertTrue(TypeEnum::isValueType($type1, TypeEnum::SHORT));
+    $this->assertTrue(TypeEnum::isValueType(TypeEnum::LONG, $type2));
+  }
+
+  function test__getValue() {
+    $type = new TypeEnum(TypeEnum::SHORT);
+    $this->assertEquals($type->value, TypeEnum::SHORT);
+  }
+
+  function testIsType() {
+    $type = new TypeEnum(TypeEnum::SHORT);
+    $this->assertTrue($type->isType(TypeEnum::SHORT));
+    $this->assertFalse($type->isType(new TypeEnum(2))); // TypeEnum::LONG
+  }
+
+  function testIsValueNamed() {
+    $type = new TypeEnum(TypeEnum::SHORT);
+    $this->assertTrue(TypeEnum::isValueNamed($type));
+    $this->assertTrue(TypeEnum::isValueNamed(TypeEnum::LONG));
+    $this->assertFalse(TypeEnum::isValueNamed(4)); // TypeEnum::ARGUMENT
+  }
+
+  function testIsNamed() {
+    $type1 = new TypeEnum(TypeEnum::SHORT);
+    $type2 = new TypeEnum(TypeEnum::LONG);
+    $type3 = new TypeEnum(TypeEnum::ARGUMENT);
+    $this->assertTrue($type1->isNamed());
+    $this->assertTrue($type2->isNamed());
+    $this->assertFalse($type3->isNamed());
+  }
+
+}


### PR DESCRIPTION
Add class for holding constants which are common accross classes
and performing simple value operations and comparisons. DEPRECATE
the current constants, which are similar but use different naming
and values to mean the same thing in other classes.

BREAKING: The original constant values used in the Command class
have changed.

 - Add enumerator class to contain Option type constant values along
with some utility functions for comparing types.
 - Replace constant values with those from TypeEnum in Option
 - Replace constant values with those from TypeEnum in Command
 - Add dependency for systems without SplTypes PECL extension
 - Tests for new class

*_Deprecated:_*
 - Option::TYPE_SHORT
 - Option::TYPE_VERBOSE
 - Option::TYPE_NAMED
 - Option::TYPE_ANONYMOUS
 - Command::OPTION_TYPE_SHORT
 - Command::OPTION_TYPE_VERBOSE
 - Command::OPTION_TYPE_ARGUMENT